### PR TITLE
Change object id by the id in the segmented images

### DIFF
--- a/Source Code/getboundary.py
+++ b/Source Code/getboundary.py
@@ -91,7 +91,8 @@ def getboundary(csv, progress_bar, entries):
                 except:
                     ar = 0
                 props = [area, perimeter, majoraxis, minoraxis, circularity, ar]
-                fronttag = [imlist[imidx], imidx + 1, objidx + 1]
+                # fronttag = [imlist[imidx], imidx + 1, objidx + 1]
+                fronttag = [imlist[imidx], imidx + 1, lab] # Add image object id
                 registry_item = fronttag + centroid + props
                 registry.append(registry_item)
                 boundarymaster.append(boundary)


### PR DESCRIPTION
Instead of storing an ordered object id, it will store the id in the input images. This way it is easier to go back to the original images in case there is a tracking or other previous classification.